### PR TITLE
fix(storybook): remove duplicate `@storybook/addon-essentials`

### DIFF
--- a/web/config/storybook.config.js
+++ b/web/config/storybook.config.js
@@ -2,5 +2,5 @@ module.exports = {
   features: {
     interactionsDebugger: true,
   },
-  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  addons: ['@storybook/addon-interactions'],
 }

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,6 @@
     "react-dom": "18.0.0"
   },
   "devDependencies": {
-    "@storybook/addon-essentials": "6.4.22",
     "@storybook/addon-interactions": "6.4.22",
     "@storybook/jest": "0.0.10",
     "@storybook/test-runner": "0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24945,7 +24945,6 @@ __metadata:
     "@redwoodjs/forms": 1.1.1
     "@redwoodjs/router": 1.1.1
     "@redwoodjs/web": 1.1.1
-    "@storybook/addon-essentials": 6.4.22
     "@storybook/addon-interactions": 6.4.22
     "@storybook/jest": 0.0.10
     "@storybook/test-runner": 0.0.7


### PR DESCRIPTION
https://github.com/redwoodjs/redwood/pull/4765 added `@storybook/addon-essentials` by default, and was included in 1.1.0

adding it twice causes an issue in webpack.

not sure if the work in https://github.com/redwoodjs/redwood/pull/4900 will help prevent this type of thing in the future. need to follow up

closes #43