### PR TITLE
build(github): add node 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
RELEASE | STATUS | CODENAME | INITIAL RELEASE | ACTIVE LTS START | MAINTENANCE LTS START | END-OF-LIFE
-- | -- | -- | -- | -- | -- | --
v14 | Maintenance LTS | Fermium | 2020-04-21 | 2020-10-27 | 2021-10-19 | 2023-04-30
v16 | Active LTS | Gallium | 2021-04-20 | 2021-10-26 | 2022-10-18 | 2024-04-30
v18 | Current |   | 2022-04-19 | 2022-10-25 | 2023-10-18 | 2025-04-30

- https://nodejs.org/en/about/releases/