### PR TITLE
build(github): wrap `test`s with `nick-fields/retry`

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -62,7 +62,8 @@ jobs:
         max_attempts: 3
         retry_on: error
         command: yarn install --immutable
-    - uses: nick-fields/retry@v2.7.0
+    - name: run jest and storybook tests
+      uses: nick-fields/retry@v2.7.0
       with:
         timeout_minutes: 3
         max_attempts: 3


### PR DESCRIPTION
```sh
yarn rw test && yarn workspace web test-storybook:ci
```
seems to be flakey.

---

see: 
- https://github.com/redwoodjs/example-storybook/runs/7394879236?check_suite_focus=true#step:6:684
- https://github.com/redwoodjs/example-storybook/runs/7289889044?check_suite_focus=true#step:6:684