### PR TITLE
chore(redwood): don't fail test teardown errors

### DIFF
--- a/.yarn/patches/@redwoodjs-testing-npm-3.3.0-b9ba484f01.patch
+++ b/.yarn/patches/@redwoodjs-testing-npm-3.3.0-b9ba484f01.patch
@@ -1,0 +1,17 @@
+diff --git a/config/jest/api/jest.setup.js b/config/jest/api/jest.setup.js
+index aaf42b55addb02b17c8b0a4670f0016d58e3fa47..9f6968ccaedf3325946b41cb9eb5fe128bb89bbb 100644
+--- a/config/jest/api/jest.setup.js
++++ b/config/jest/api/jest.setup.js
+@@ -222,7 +222,11 @@ beforeAll(async () => {
+   // Disable perRequestContext for tests
+   process.env.DISABLE_CONTEXT_ISOLATION = '1'
+   if (wasDbUsed()) {
+-    await configureTeardown()
++    try {
++      await configureTeardown();
++    } catch (e) {
++      console.error(e);
++    }
+   }
+ })
+ 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@storybook/addon-a11y": "6.5.13",
     "@storybook/builder-webpack5": "6.5.13",
     "@storybook/manager-webpack5": "6.5.13",
-    "@storybook/react": "6.5.13"
+    "@storybook/react": "6.5.13",
+    "@redwoodjs/testing@3.3.0": "patch:@redwoodjs/testing@npm%3A3.3.0#./.yarn/patches/@redwoodjs-testing-npm-3.3.0-b9ba484f01.patch"
   },
   "packageManager": "yarn@3.2.4"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4247,6 +4247,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@redwoodjs/testing@patch:@redwoodjs/testing@npm%3A3.3.0#./.yarn/patches/@redwoodjs-testing-npm-3.3.0-b9ba484f01.patch::locator=root-workspace-0b6124%40workspace%3A.":
+  version: 3.3.0
+  resolution: "@redwoodjs/testing@patch:@redwoodjs/testing@npm%3A3.3.0#./.yarn/patches/@redwoodjs-testing-npm-3.3.0-b9ba484f01.patch::version=3.3.0&hash=7fc8ae&locator=root-workspace-0b6124%40workspace%3A."
+  dependencies:
+    "@babel/runtime-corejs3": 7.19.4
+    "@redwoodjs/auth": 3.3.0
+    "@redwoodjs/graphql-server": 3.3.0
+    "@redwoodjs/internal": 3.3.0
+    "@redwoodjs/router": 3.3.0
+    "@redwoodjs/web": 3.3.0
+    "@storybook/addon-a11y": 6.5.12
+    "@storybook/addon-docs": 6.5.12
+    "@storybook/addon-essentials": 6.5.12
+    "@storybook/builder-webpack5": 6.5.12
+    "@storybook/manager-webpack5": 6.5.12
+    "@storybook/react": 6.5.12
+    "@testing-library/jest-dom": 5.16.5
+    "@testing-library/react": 12.1.5
+    "@testing-library/react-hooks": 8.0.1
+    "@testing-library/user-event": 14.4.3
+    "@types/aws-lambda": 8.10.107
+    "@types/babel-core": 6.25.7
+    "@types/jest": 29.1.2
+    "@types/node": 16.11.65
+    "@types/react": 17.0.50
+    "@types/react-dom": 17.0.17
+    "@types/webpack": 5.28.0
+    babel-jest: 29.1.2
+    babel-plugin-inline-react-svg: 2.0.1
+    core-js: 3.25.5
+    fast-glob: 3.2.12
+    jest: 29.1.2
+    jest-environment-jsdom: 29.1.2
+    jest-watch-typeahead: 2.2.0
+    msw: 0.47.4
+    ts-toolbelt: 9.6.0
+    whatwg-fetch: 3.6.2
+  checksum: df2eec47102adde4b0e9f1fdfa05d1d1700d470f1d8e4312dcacd91066288541838a696db77bb093a89742a8671b5a29344da692884f2d6539460dff4b1fdeab
+  languageName: node
+  linkType: hard
+
 "@redwoodjs/web@npm:3.3.0":
   version: 3.3.0
   resolution: "@redwoodjs/web@npm:3.3.0"


### PR DESCRIPTION
getting really odd test failure errors - this is meant to fix

```
...
FAIL api api/src/services/comments/comments.test.js
  comments
    ✕ returns all comments for a single post from the database (5 ms)
    ✕ creates a new comment (6 ms)
    ✕ allows admins and moderators to delete a comment (4 ms)
    ✕ does not allow a non-moderator to delete a comment (4 ms)
    ✕ does not allow a logged out user to delete a comment (5 ms)

  ● comments › returns all comments for a single post from the database

    TypeError: Cannot redefine property: __RESOLVED_TMP_DIR__
        at Function.defineProperty (<anonymous>)

      at Object.get (node_modules/jest-environment-node/build/index.js:100:20)
      at Object.<anonymous> (node_modules/temp-write/node_modules/temp-dir/index.js:7:12)
      at Object.<anonymous> (node_modules/temp-write/index.js:8:17)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/queryEngineCommons.js:44:33)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/getConfig.js:43:33)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/index.js:29:24)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/index.js:120:25)
      at configureTeardown (node_modules/@redwoodjs/testing/config/jest/api/jest.setup.js:35:23)
      at Object.<anonymous> (node_modules/@redwoodjs/testing/config/jest/api/jest.setup.js:225:11)

  ● comments › returns all comments for a single post from the database

    TypeError: Cannot redefine property: __RESOLVED_TMP_DIR__
        at Function.defineProperty (<anonymous>)

      at Object.get (node_modules/jest-environment-node/build/index.js:100:20)
      at Object.<anonymous> (node_modules/temp-write/node_modules/temp-dir/index.js:7:12)
      at Object.<anonymous> (node_modules/temp-write/index.js:8:17)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/queryEngineCommons.js:44:33)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/getConfig.js:43:33)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/engine-commands/index.js:29:24)
      at Object.<anonymous> (node_modules/@prisma/internals/dist/index.js:120:25)
      at getQuoteStyle (node_modules/@redwoodjs/testing/config/jest/api/jest.setup.js:60:42)
      at teardown (node_modules/@redwoodjs/testing/config/jest/api/jest.setup.js:139:28)
      at Object.<anonymous> (node_modules/@redwoodjs/testing/config/jest/api/jest.setup.js:237:11)
...
```