### PR TITLE
chore(node): remove node 14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
it will be EoL soon ( _2023-04-30_ ) , and is causing flakiness in CI/CD currently, so just removing to keep it moving.

---


- https://github.com/nodejs/release#release-schedule