### PR TITLE
fix(github@actions): workaround `redwoodjs` bug

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -70,7 +70,7 @@ jobs:
         timeout_minutes: 3
         max_attempts: 3
         retry_on: error
-        command: yarn rw test && yarn workspace web test-storybook:ci
+        command: yarn rw test api && yarn rw test web && yarn workspace web test-storybook:ci
     - uses: actions/upload-artifact@v3.1.1
       with:
         name: coverage-for-${{github.sha}}-node-${{matrix.node-version}}


### PR DESCRIPTION
see: 
- [API tests fail in github actions, but pass locally](https://community.redwoodjs.com/t/api-tests-fail-in-github-actions-but-pass-locally/4251/2?u=bitshift)
- https://github.com/redwoodjs/redwood/issues/6814
- https://github.com/redwoodjs/redwood/pull/6438#issuecomment-1304857167