### PR TITLE
chore(github): remove Node 14

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -46,7 +46,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
End of life is `2023-04-30`

https://github.com/nodejs/release#release-schedule

Getting ahead since this runtime is failing.

https://github.com/redwoodjs/example-storybook/actions/runs/3514685282/jobs/5889003217